### PR TITLE
Removes deletion of saved zone during activation

### DIFF
--- a/class-shared-shipping-method.php
+++ b/class-shared-shipping-method.php
@@ -163,8 +163,8 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 
 		foreach ( $shipping_rates as $shipping_rate ) {
 			$rate = array(
-				'id'      => $this->get_rate_id(),
-				'label'   => $this->title,
+				'id'      => $shipping_rate->get_id(),
+				'label'   => $shipping_rate->get_label(),
 				'cost'    => $shipping_rate->get_cost(),
 				'package' => $package,
 			);

--- a/class-shared-shipping-method.php
+++ b/class-shared-shipping-method.php
@@ -15,7 +15,7 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 	public function __construct( $instance_id = 0 ) {
 		$this->instance_id        = absint( $instance_id );
 		$this->id                 = 'shared_shipping_method';
-		$this->method_title       = __( 'Shared Shipping Methods', 'woocommerce' );
+		$this->method_title       = __( 'Shared Shipping Method', 'woocommerce' );
 		$this->method_description = __( 'Use an existing shipping method from another zone.', 'woocommerce' );
 		$this->title              = 'Shared Shipping Method';
 		$this->supports           = array(
@@ -53,6 +53,18 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 		$shared_shipping_zone = get_option( 'shared_shipping_zone' );
 
 		if ( ! $shared_shipping_zone ) {
+			$this->instance_form_fields = array(
+				'title' => array(
+					'title'       => __( 'Shared Shipping Zone not Set', 'woocommerce' ),
+					'type'        => 'title',
+					'description' => sprintf(
+						/* translators: %s: URL to the Shipping Options page. */
+						__( 'Please select a shared shipping method zone on the <a href="%s">Shipping Options</a> page.', 'woocommerce' ),
+						admin_url( 'admin.php?page=wc-settings&tab=shipping&section=options' )
+					),
+					'desc_tip'    => false,
+				),
+			);
 			return;
 		}
 

--- a/class-shared-shipping-method.php
+++ b/class-shared-shipping-method.php
@@ -42,8 +42,8 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 	}
 
 	/**
-	 * Initialize form fields for this shipping method.  If the shared shipping zone has been deleted
-	 * we delete the existing option and return.
+	 * Initialize form fields for this shipping method.  If the set shared shipping
+	 * zone is invalid, we delete the option.
 	 *
 	 * @throws Exception If the shared shipping zone is invalid.
 	 * @return void
@@ -60,6 +60,14 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 			$selected_zone = new WC_Shipping_Zone( $shared_shipping_zone );
 		} catch ( Exception $e ) {
 			delete_option( 'shared_shipping_zone' );
+			$logger = wc_get_logger();
+			$logger->log(
+				'error',
+				'Invalid shared shipping zone.  Shared shipping zone ' . $shared_shipping_zone . ' deleted.',
+				array(
+					'source' => 'Shared Shipping Methods',
+				)
+			);
 			return;
 		}
 

--- a/class-shared-shipping-method.php
+++ b/class-shared-shipping-method.php
@@ -15,8 +15,8 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 	public function __construct( $instance_id = 0 ) {
 		$this->instance_id        = absint( $instance_id );
 		$this->id                 = 'shared_shipping_method';
-		$this->method_title       = __( 'Shared Shipping Method', 'woocommerce' );
-		$this->method_description = __( 'Use an existing shipping method from another zone.', 'woocommerce' );
+		$this->method_title       = __( 'Shared Shipping Method', 'shared-shipping-methods' );
+		$this->method_description = __( 'Use an existing shipping method from another zone.', 'shared-shipping-methods' );
 		$this->title              = 'Shared Shipping Method';
 		$this->supports           = array(
 			'shipping-zones',
@@ -55,11 +55,11 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 		if ( ! $shared_shipping_zone ) {
 			$this->instance_form_fields = array(
 				'title' => array(
-					'title'       => __( 'Shared Shipping Zone not Set', 'woocommerce' ),
+					'title'       => __( 'Shared Shipping Zone not Set', 'shared-shipping-methods' ),
 					'type'        => 'title',
 					'description' => sprintf(
 						/* translators: %s: URL to the Shipping Options page. */
-						__( 'Please select a shared shipping method zone on the <a href="%s">Shipping Options</a> page.', 'woocommerce' ),
+						__( 'Please select a shared shipping method zone on the <a href="%s">Shipping Options</a> page.', 'shared-shipping-methods' ),
 						admin_url( 'admin.php?page=wc-settings&tab=shipping&section=options' )
 					),
 					'desc_tip'    => false,
@@ -92,14 +92,14 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 
 		$this->instance_form_fields = array(
 			'title'                  => array(
-				'title'       => __( 'Title', 'woocommerce' ),
+				'title'       => __( 'Title', 'shared-shipping-methods' ),
 				'type'        => 'text',
-				'description' => __( 'This controls the title which the user sees during checkout.', 'woocommerce' ),
+				'description' => __( 'This controls the title which the user sees during checkout.', 'shared-shipping-methods' ),
 				'default'     => $this->method_title,
 				'desc_tip'    => true,
 			),
 			'selected_shared_method' => array(
-				'title'   => __( 'Select other method', 'woocommerce' ),
+				'title'   => __( 'Select other method', 'shared-shipping-methods' ),
 				'type'    => 'select',
 				'class'   => 'wc-enhanced-select',
 				'default' => '',

--- a/class-shared-shipping-method.php
+++ b/class-shared-shipping-method.php
@@ -17,7 +17,7 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 		$this->id                 = 'shared_shipping_method';
 		$this->method_title       = __( 'Shared Shipping Method', 'shared-shipping-methods' );
 		$this->method_description = __( 'Use an existing shipping method from another zone.', 'shared-shipping-methods' );
-		$this->title              = 'Shared Shipping Method';
+		$this->title              = __( 'Shared Shipping Method', 'shared-shipping-methods' );
 		$this->supports           = array(
 			'shipping-zones',
 			'instance-settings',

--- a/class-shared-shipping-method.php
+++ b/class-shared-shipping-method.php
@@ -140,12 +140,11 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 
 			if ( $shipping_method->id === $shipping_method_id ) {
 				$class_name = get_class( $shipping_method );
-				$instance   = new $class_name( $method_instance_id );
 				break;
 			}
 		}
 
-		if ( ! isset( $instance ) ) {
+		if ( ! isset( $class_name ) ) {
 			$logger = wc_get_logger();
 			$logger->log(
 				'error',
@@ -157,6 +156,7 @@ class Shared_Shipping_Method extends WC_Shipping_Method {
 			return;
 		}
 
+		$instance = new $class_name( $method_instance_id );
 		$instance->calculate_shipping( $package );
 
 		$shipping_rates = $instance->get_rates_for_package( $package );

--- a/class-shared-shipping-methods-settings.php
+++ b/class-shared-shipping-methods-settings.php
@@ -103,7 +103,7 @@ class Shared_Shipping_Methods_Settings {
 		$shared_shipping_zone = get_option( 'shared_shipping_zone' );
 
 		// If the shared shipping zone is set we don't need to create a new zone.
-		if ( ! empty( $shared_shipping_zone ) ) {
+		if ( ! isset( $shared_shipping_zone ) ) {
 			return;
 		}
 

--- a/class-shared-shipping-methods-settings.php
+++ b/class-shared-shipping-methods-settings.php
@@ -102,10 +102,8 @@ class Shared_Shipping_Methods_Settings {
 
 		$shared_shipping_zone = get_option( 'shared_shipping_zone' );
 
-		// If the shared shipping zone is set to none, delete the option.  If it is set, return.
-		if ( '' === $shared_shipping_zone ) {
-			delete_option( 'shared_shipping_zone' );
-		} elseif ( ! empty( $shared_shipping_zone ) ) {
+		// If the shared shipping zone is set we don't need to create a new zone.
+		if ( ! empty( $shared_shipping_zone ) ) {
 			return;
 		}
 
@@ -122,7 +120,13 @@ class Shared_Shipping_Methods_Settings {
 
 		} catch ( Exception $e ) {
 			$logger = wc_get_logger();
-			$logger->log( 'error', 'Failed to save shared_shipping_zone option for zone id: ' . $zone_id, array( 'source' => 'Shared Shipping Methods' ) );
+			$logger->log(
+				'error',
+				'Failed to save shared_shipping_zone option for zone id: ' . $zone_id,
+				array(
+					'source' => 'Shared Shipping Methods',
+				)
+			);
 		}
 
 	}

--- a/class-shared-shipping-methods-settings.php
+++ b/class-shared-shipping-methods-settings.php
@@ -90,10 +90,14 @@ class Shared_Shipping_Methods_Settings {
 	}
 
 	/**
-	 * Adds a new shared shipping zone when the plugin is activated
-	 * if one isn't set.  The order is set to 100 so it's at the bottom
-	 * of the list. The location is set to Antartica to prevent these
-	 * shipping methods from showing up in the cart.
+	 * Handles the activation of the plugin.
+	 *
+	 * When the plugin is activated, it checks to see if the shared_shipping_zone
+	 * option is set.  If it isn't, a new zone is created and the ID is saved to
+	 * the option.
+	 * The order is set to 100 so it's at the bottom of the list.
+	 * The location is set to Antartica to prevent these shipping methods from being
+	 * directly offered to customers in the cart.
 	 *
 	 * @throws Exception If the zone fails to save.
 	 * @return void

--- a/class-shared-shipping-methods-settings.php
+++ b/class-shared-shipping-methods-settings.php
@@ -47,8 +47,8 @@ class Shared_Shipping_Methods_Settings {
 		}
 
 		$new_option[] = array(
-			'title'    => __( 'Share shipping zone', 'woocommerce' ),
-			'desc_tip' => __( 'Select a zone to share shipping methods', 'woocommerce' ),
+			'title'    => __( 'Share shipping methods zone', 'shared-shipping-methods' ),
+			'desc_tip' => __( 'Select a source zone for sharing shipping methods.', 'shared-shipping-methods' ),
 			'id'       => 'shared_shipping_zone',
 			'type'     => 'select',
 			'class'    => 'wc-enhanced-select',

--- a/class-shared-shipping-methods-settings.php
+++ b/class-shared-shipping-methods-settings.php
@@ -103,7 +103,7 @@ class Shared_Shipping_Methods_Settings {
 		$shared_shipping_zone = get_option( 'shared_shipping_zone' );
 
 		// If the shared shipping zone is set we don't need to create a new zone.
-		if ( ! isset( $shared_shipping_zone ) ) {
+		if ( isset( $shared_shipping_zone ) ) {
 			return;
 		}
 

--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ Once activated, the plugin creates a new shipping zone named "Shared Shipping Me
 
 Get started by adding the shipping methods you'd like to share.  Here's how.
 
-1.  Navigate to WooCommerce > Settings > Shipping and select the "Shared Shipping Methods" zone.  
+1. Navigate to `WooCommerce > Settings > Shipping` and select the "Shared Shipping Methods" zone.  
 2. Add a new shipping method, ensuring you've filled all necessary settings.
 3. Repeat these steps to share additional shipping methods.
 

--- a/readme.md
+++ b/readme.md
@@ -28,3 +28,7 @@ Get started by adding the shipping methods you'd like to share.  Here's how.
 6. Save your settings.
 
 To specify the shared shipping methods zone, go to `WooCommerce > Settings > Shipping > Shipping Options`. The selected zone in this setting will be considered as the source of available shared shipping methods.
+
+## Contributing
+
+If you spot any issues or have feature requests, please open up an issue or feel free to submit a pull request.

--- a/shared-shipping-methods.php
+++ b/shared-shipping-methods.php
@@ -10,7 +10,7 @@
  * Author URI:        https://justabill.blog
  * License:           GPL v2 or later
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.html
- * Text Domain:       shared-shipping-methods
+ * Text Domain:       shared-shipping-methods -- to be updated
  * Domain Path:       /languages
  */
 


### PR DESCRIPTION
When activating this plugin for the first time, we need to create a new shipping zone to house our shared shipping methods.  Originally, I checked to see if there was a value set for the `shared_shipping_zone` option and if it was set, but empty, I deleted the option and created a new zone.

This PR revises this behavior so that we only create a new zone when the `shared_shipping_zone` isn't set at all.  If it's set to a zone or is empty, we skip creating a new zone.  

## Testing
1.  Install and activate this plugin.
2. Navigate to WooCommerce > Settings > Shipping and verify that there is a "Shared Shipping Methods" zone.
3. Now select the "Shipping options" link at the top.  In the drop-down for the "Shared Shipping zone" select "none" and save your changes.
4. Go to the plugins section of your admin and deactivate the "Shared Shipping Methods" plugin.  Then activate it again.
5. Return to WooCommerce > Settings > Shipping and verify that a second "Shared Shipping Methods" zone has _not_ been created.